### PR TITLE
adding typecover patch for different type cover ids

### DIFF
--- a/typecover.patch
+++ b/typecover.patch
@@ -1,0 +1,109 @@
+diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+index 8b63879..74aadf6 100644
+--- a/drivers/hid/hid-core.c
++++ b/drivers/hid/hid-core.c
+@@ -704,8 +704,12 @@ static void hid_scan_collection(struct hid_parser *parser, unsigned type)
+                hid->group = HID_GROUP_SENSOR_HUB;
+
+        if (hid->vendor == USB_VENDOR_ID_MICROSOFT &&
+-           hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3 &&
+-           hid->group == HID_GROUP_MULTITOUCH)
++           (hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3 ||
++            hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3_JP ||
++            hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3_1 ||
++            hid->product == USB_DEVICE_ID_MS_TYPE_COVER_3_2 ||
++            hid->product == USB_DEVICE_ID_MS_POWER_COVER) &&
++            hid->group == HID_GROUP_MULTITOUCH)
+                hid->group = HID_GROUP_GENERIC;
+ }
+
+@@ -1861,6 +1865,10 @@ static const struct hid_device_id hid_have_special_driver[] = {
+        { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_WIRELESS_OPTICAL_DESKTOP_3_0) },
+        { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_OFFICE_KB) },
+        { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3) },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_POWER_COVER) },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_JP) },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_1) },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_2) },
+        { HID_USB_DEVICE(USB_VENDOR_ID_MONTEREY, USB_DEVICE_ID_GENIUS_KB29E) },
+        { HID_USB_DEVICE(USB_VENDOR_ID_MSI, USB_DEVICE_ID_MSI_GT683R_LED_PANEL) },
+        { HID_USB_DEVICE(USB_VENDOR_ID_NTRIG, USB_DEVICE_ID_NTRIG_TOUCH_SCREEN) },
+
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index fd6687a..dc391ca 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -659,6 +659,10 @@
+ #define USB_DEVICE_ID_MS_TOUCH_COVER_2   0x07a7
+ #define USB_DEVICE_ID_MS_TYPE_COVER_2    0x07a9
+ #define USB_DEVICE_ID_MS_TYPE_COVER_3    0x07dc
++#define USB_DEVICE_ID_MS_TYPE_COVER_3_JP 0x07dd
++#define USB_DEVICE_ID_MS_TYPE_COVER_3_1  0x07de
++#define USB_DEVICE_ID_MS_TYPE_COVER_3_2  0x07e2
++#define USB_DEVICE_ID_MS_POWER_COVER     0x07da
+
+ #define USB_VENDOR_ID_MOJO             0x8282
+ #define USB_DEVICE_ID_RETRO_ADAPTER    0x3201
+
+diff --git a/drivers/hid/hid-microsoft.c b/drivers/hid/hid-microsoft.c
+index cacda43..ffee162 100644
+--- a/drivers/hid/hid-microsoft.c
++++ b/drivers/hid/hid-microsoft.c
+@@ -276,6 +276,14 @@ static const struct hid_device_id ms_devices[] = {
+                .driver_data = MS_DUPLICATE_USAGES },
+        { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3),
+                .driver_data = MS_HIDINPUT },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_JP),
++                .driver_data = MS_HIDINPUT },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_1),
++                .driver_data = MS_HIDINPUT },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_2),
++                .driver_data = MS_HIDINPUT },
++       { HID_USB_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_POWER_COVER),
++                .driver_data = MS_HIDINPUT },
+
+        { HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_PRESENTER_8K_BT),
+                .driver_data = MS_PRESENTER },
+
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index 55e89b1..2156b21 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -1260,6 +1260,20 @@ static const struct hid_device_id mt_devices[] = {
+                MT_USB_DEVICE(USB_VENDOR_ID_ILITEK,
+                        USB_DEVICE_ID_ILITEK_MULTITOUCH) },
+
++       /* Microsoft Type Cover */
++       { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++               MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++                       USB_DEVICE_ID_MS_TYPE_COVER_3) },
++       { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++               MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++                       USB_DEVICE_ID_MS_TYPE_COVER_3_JP) },
++       { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++               MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++                       USB_DEVICE_ID_MS_TYPE_COVER_3_1) },
++       { .driver_data = MT_CLS_EXPORT_ALL_INPUTS,
++               MT_USB_DEVICE(USB_VENDOR_ID_MICROSOFT,
++                       USB_DEVICE_ID_MS_TYPE_COVER_3_2) },
++
+        /* MosArt panels */
+        { .driver_data = MT_CLS_CONFIDENCE_MINUS_ONE,
+                MT_USB_DEVICE(USB_VENDOR_ID_ASUS,
+
+diff --git a/drivers/hid/usbhid/hid-quirks.c b/drivers/hid/usbhid/hid-quirks.c
+index 5c5f97d..7d95fcd 100644
+--- a/drivers/hid/usbhid/hid-quirks.c
++++ b/drivers/hid/usbhid/hid-quirks.c
+@@ -83,6 +83,10 @@ static const struct hid_blacklist {
+        { USB_VENDOR_ID_LOGITECH, USB_DEVICE_ID_LOGITECH_C077, HID_QUIRK_ALWAYS_POLL },
+        { USB_VENDOR_ID_MGE, USB_DEVICE_ID_MGE_UPS, HID_QUIRK_NOGET },
+        { USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3, HID_QUIRK_NO_INIT_REPORTS },
++       { USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_JP, HID_QUIRK_NO_INIT_REPORTS },
++       { USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_1, HID_QUIRK_NO_INIT_REPORTS },
++       { USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_TYPE_COVER_3_2, HID_QUIRK_NO_INIT_REPORTS },
++       { USB_VENDOR_ID_MICROSOFT, USB_DEVICE_ID_MS_POWER_COVER, HID_QUIRK_NO_INIT_REPORTS },
+        { USB_VENDOR_ID_MSI, USB_DEVICE_ID_MSI_GT683R_LED_PANEL, HID_QUIRK_NO_INIT_REPORTS },
+        { USB_VENDOR_ID_NEXIO, USB_DEVICE_ID_NEXIO_MULTITOUCH_PTI0750, HID_QUIRK_NO_INIT_REPORTS },
+        { USB_VENDOR_ID_NOVATEK, USB_DEVICE_ID_NOVATEK_MOUSE, HID_QUIRK_NO_INIT_REPORTS },
+


### PR DESCRIPTION
I used your patches and guide to get up and running with ubuntu 15.04 on my surface pro3. However my keyboard didn't work. This was because my type cover product id is 07e2 and the kernel only supports the 07dc type cover. I created this patch to add support for all the type covers so no on can run into this issue. 
